### PR TITLE
Do not panic on NaN

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -228,7 +228,7 @@ func ProcessJMXMetrics(client *dogstatsd.Client) {
 		metric, err := getMetric(metricName)
 
 		if err != nil {
-			log.Printf("getMetric(%q): %v", err)
+			log.Printf("getMetric(%q): %v", metricName, err)
 			continue
 		}
 

--- a/metrics.go
+++ b/metrics.go
@@ -221,7 +221,7 @@ func sendJMXMetric(client *dogstatsd.Client, metricCatagory string, attribute JM
 			datadogLabel := fmt.Sprintf("data.presto.%s.%s", metricCatagory, attribute.Name)
 			client.Gauge(datadogLabel, val, nil, 1.0)
 		default:
-			log.Println("skipping attribute %q: cannot handle value %v type %T", attribute.Name, val, val)
+			log.Printf("skipping attribute %q: cannot handle value %v type %T", attribute.Name, val, val)
 		}
 	}
 }


### PR DESCRIPTION
The datadog client insists on float64s, which were just assumed to be
always present in the JSON data from presto. However if presto was
starting up then some numbers were returned as NaN. NaN is not a valid
number in JSON so are encoded as the string, "NaN". When they were
decoded on our side, this converted them to a string, not a float64 and
the blind conversion in sendJMXMetric would fail.

This change comes with no guarentee. If it breaks your application, you
get to keep both pieces.

Fixes #1 